### PR TITLE
Fix exception handling for non strings

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -120,7 +120,8 @@ class App extends Component {
       })      
       .catch(err => {
         // Last.FM API errors usualy missing a period, if so append it for better UX
-        err = (typeof err === 'string') && err.endsWith('.') ? err : err + '.';
+        if(typeof err === 'string')
+          err = err.endsWith('.') ? err : err + '.';
         this.setState({
           error: err
         })

--- a/src/App.js
+++ b/src/App.js
@@ -120,7 +120,7 @@ class App extends Component {
       })      
       .catch(err => {
         // Last.FM API errors usualy missing a period, if so append it for better UX
-        err = err.endsWith('.') ? err : err + '.';
+        err = (typeof err === 'string') && err.endsWith('.') ? err : err + '.';
         this.setState({
           error: err
         })


### PR DESCRIPTION
Exceptions from Last.FM API sometimes aren't a string, this PR makes sure they are strings before checking if they end with a period, to avoid crashing.