### PR TITLE
Fixed wrong variable use for album data request

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -56,7 +56,7 @@ async function getAlbums(service, token) {
     // Spotify limits each request to 50 albums, so we have to create multiple requests.
     // We'll take 1000 albums at most.
     for (let offset = 0; offset < 1000; offset += limit) {
-      promises.push(getServiceAlbums(limit));
+      promises.push(getServiceAlbums(offset));
     }
 
     const results = await Promise.all(promises);


### PR DESCRIPTION
This caused the offset to always be 50 - which means that user with less than 50 albums didn't have any information available, and users with more than 50 albums retrieved only their 50 - 100 numbered albums.