### PR TITLE
Fix hearts not greying out on failed guess

### DIFF
--- a/src/components/GameHeader/GameHeader.js
+++ b/src/components/GameHeader/GameHeader.js
@@ -6,7 +6,7 @@ import './GameHeader.css';
 function GameHeader(props) {
   return (
     <div className="game-top-bar">
-      <Hearts lives={4 - props.currentGame.failedGuesses} />
+      <Hearts lives={4 - props.failedGuesses} />
       <ProgressBar type="thin" total={props.totalAlbums} progress={props.albumsProgress} />
       <div className="game-top-bar-settings-icon" onClick={() => props.setSettingsDisplay(true)}>
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25">

--- a/src/views/Game/Game.js
+++ b/src/views/Game/Game.js
@@ -138,7 +138,7 @@ class Game extends Component {
         )}
         <GameHeader
           setSettingsDisplay={this.setSettingsDisplay}
-          currentGame={this.state.currentGame}
+          failedGuesses={this.state.currentGame.failedGuesses}
           totalAlbums={this.props.totalAlbums}
           albumsProgress={this.props.progress}
         />

--- a/src/views/Game/Game.test.js
+++ b/src/views/Game/Game.test.js
@@ -205,3 +205,10 @@ it('removes keydown listener on unmount', () => {
   wrapper.unmount();
   expect('keydown' in map).toBeFalsy();
 });
+
+it('displays dying heart on failed guess', () => {
+  // Wrong guess
+  mainWrapper.instance().handleLetterPress('b');
+  console.log(mainWrapper.find('.heart-grey').length);
+  expect(mainWrapper.find('.heart-grey')).toHaveLength(1);
+});

--- a/src/views/Game/Game.test.js
+++ b/src/views/Game/Game.test.js
@@ -209,6 +209,6 @@ it('removes keydown listener on unmount', () => {
 it('displays dying heart on failed guess', () => {
   // Wrong guess
   mainWrapper.instance().handleLetterPress('b');
-  console.log(mainWrapper.find('.heart-grey').length);
+  mainWrapper.update();
   expect(mainWrapper.find('.heart-grey')).toHaveLength(1);
 });


### PR DESCRIPTION
The `failedGuesses` property was nested in the `currentGame` object which was passed as a prop to the `GameHeader` component. 

Since I applied `React.memo` to the `GameHeader` component, it didn't detect changes that occurred in the `currentGame` object properties. 

Now we pass directly the `failedGuesses` value as a prop, which fixes the issue and lets `React.memo` detect the changes.


